### PR TITLE
feat: remove memory-mapped locale-archive

### DIFF
--- a/nix/containerImages.nix
+++ b/nix/containerImages.nix
@@ -64,7 +64,6 @@
         chmod -R u+w .
         ${lib.optionalString includeShell "mkdir -p etc; echo \"root:x:0:0:root:/:/bin/sh\" > etc/passwd"}
         ${lib.optionalString (archs != []) (conf + ldconfigScript)}
-        ${lib.optionalString (lib.length archs > 1) "ln -sf /usr/lib/i686-linux-gnu/locale/locale-archive usr/lib/x86_64-linux-gnu/locale/locale-archive"}
         chmod -R u-w .
       '';
     };

--- a/nix/uninative.nix
+++ b/nix/uninative.nix
@@ -24,7 +24,7 @@ in
       _sln() { mkdir -p "$(dirname "$2")" && [ ! -e "$2" ] && ln -sf "$1" "$2"; }
       _smv() { mkdir -p "$(dirname "$2")" && [ ! -e "$2" ] && mv "$1" "$2"; }
 
-      find . -type d -name 'audit' -o -name '.debug' | xargs rm -rf
+      find . -type d -name 'audit' -o -name '.debug' -o -name 'locale' | xargs rm -rf
       rm -rf usr/bin sbin var etc/ld.so.*
 
       for dir in lib usr/lib; do


### PR DESCRIPTION
This update removes the memory-mapped locale-archive file, significantly reducing the effective size of the image. According to the referenced article [1], this removal does not impact the functionality of test binaries, except for the handling of non-standard, explicitly requested locales.

[1] https://web.archive.org/web/20240418063127/https://www.openeuler.org/en/blog/wangshuo/Using%20glibc%20Locales/Using_glibc_Locales.html