### PR TITLE
fix: glibc binary tests

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,10 +7,9 @@
   };
 
   mkTestGlibcBinary = {is32Bit ? false}:
-    nixpkgs.callPackage ./testGlibcBinary.nix {
+    nixpkgs.callPackage ./nix/testGlibcBinary.nix {
       is32Bit = is32Bit;
-      # nixpkgs 23.05 has the latest glibc (2.37) supported by uninative
-      nixpkgs_src = external_sources.nixpkgs-23_05;
+      nixpkgs_src = external_sources.nixpkgs;
     };
 
   busyboxStatic = nixpkgs.callPackage ./nix/busyboxStatic.nix {};

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -10,17 +10,5 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/08b9151ed40350725eb40b1fe96b0b86304a654b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "nixpkgs-23_05": {
-        "branch": "nixos-23.05",
-        "description": "Nix Packages collection",
-        "homepage": null,
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "6b70761ea8c896aff8994eb367d9526686501860",
-        "sha256": "08np8p4h040jq4p2jlps99z38lhwg3yr2q64dqh8rbhq1kx6jzpm",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6b70761ea8c896aff8994eb367d9526686501860.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -50,7 +50,7 @@ in
       buildStarterKitTest {
         name = "starterkit-${arch}-testGlibcBinary";
         testImage = (builtins.getAttr arch containerImages).image;
-        testBinary = (builtins.getAttr arch testGlibcBinary);
+        testBinary = builtins.getAttr arch testGlibcBinary;
         cmd = ["/bin/hello_cpp"];
       }
   )
@@ -58,7 +58,7 @@ in
     "x86_64-ubuntu" = buildStarterKitTest {
       name = "starterkit-x86_64-testUbuntuDateutils";
       testImage = (builtins.getAttr "ash-x86_64" containerImages).image;
-      testBinary = (builtins.getAttr "x86_64" ubuntuDateutils);
+      testBinary = builtins.getAttr "x86_64" ubuntuDateutils;
       cmd = ["/bin/dateutils.dseq" "2024-04-01" "2024-04-25" "--skip" "sat,sun"];
     };
   }


### PR DESCRIPTION
This update fixes testGlibcBinary tests.
Changes include corrected path to testGlibcBinary.nix in toplevel callPackage, removal of unused nix source channel, and proper storepath reference stripping from test binaries to avoid polluting effective test container images.