### PR TITLE
feat: adds libstdcxx variants

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,14 +5,12 @@
     inherit localSystem;
     config = {};
   };
-  
+
   devShell = nixpkgs.callPackage ./nix/devShell.nix {};
 
   busyboxStatic = nixpkgs.callPackage ./nix/pkgs/busyboxStatic.nix {};
 
-  mkUninative = arch: nixpkgs.callPackage ./nix/pkgs/uninative.nix {uninative-arch = arch;};
-
-  uninative = nixpkgs.lib.genAttrs ["x86_64" "i686"] mkUninative;
+  uninative = nixpkgs.callPackage ./nix/pkgs/uninative.nix {};
 
   containerImages = nixpkgs.callPackage ./nix/containers/images.nix {inherit busyboxStatic uninative;};
 

--- a/nix/containers/tests.nix
+++ b/nix/containers/tests.nix
@@ -43,21 +43,21 @@
   };
 in
   lib.genAttrs [
-    "i686"
-    "x86_64"
+    "i686-cc"
+    "x86_64-cc"
   ] (
     arch:
       buildStarterKitTest {
         name = "starterkit-${arch}-helloWorldGlibc";
         testImage = (builtins.getAttr "ash-${arch}" containerImages).image;
-        testBinary = builtins.getAttr arch helloWorldGlibc;
+        testBinary = builtins.getAttr (builtins.replaceStrings ["-cc"] [""] arch) helloWorldGlibc;
         cmd = ["/bin/hello_cpp"];
       }
   )
   // {
-    "x86_64-ubuntu" = buildStarterKitTest {
-      name = "starterkit-x86_64-testUbuntuDateutils";
-      testImage = (builtins.getAttr "ash-x86_64" containerImages).image;
+    "x86_64-cc-ubuntu" = buildStarterKitTest {
+      name = "starterkit-x86_64-cc-testUbuntuDateutils";
+      testImage = (builtins.getAttr "ash-x86_64-cc" containerImages).image;
       testBinary = builtins.getAttr "x86_64" ubuntuDateutils;
       cmd = ["/bin/dateutils.dseq" "2024-04-01" "2024-04-25" "--skip" "sat,sun"];
     };

--- a/nix/pkgs/uninative.nix
+++ b/nix/pkgs/uninative.nix
@@ -1,46 +1,99 @@
 {
   stdenv,
-  uninative-arch ? "x86_64",
+  fetchurl,
+  lib,
 }: let
+  inherit
+    (lib)
+    cartesianProductOfSets
+    concatStringsSep
+    filter
+    nameValuePair
+    listToAttrs
+    optionalString
+    ;
+
   pname = "yocto-uninative";
   version = "4.4";
   baseURL = "http://downloads.yoctoproject.org/releases/uninative";
 
-  src = builtins.fetchurl {
-    url = "${baseURL}/${version}/${uninative-arch}-nativesdk-libc.tar.xz";
-    sha256 =
-      if uninative-arch == "i686"
-      then "1k2zwh7jy8a65q3nxwx8pxja1ab1m3cy9vaf6k02q27h51w64a4z"
-      else "00m3fad068w93ycd36fgh79jqyhpb0fji1zw65lqifz29cl5876q";
+  variants = cartesianProductOfSets {
+    arch = ["x86_64" "i686"];
+    cc = [true false];
+  };
+
+  buildUninative = {
+    name,
+    arch,
+    cc,
+  }:
+    stdenv.mkDerivation {
+      inherit name;
+
+      src = fetchurl {
+        url = "${baseURL}/${version}/${arch}-nativesdk-libc.tar.xz";
+        sha256 =
+          if arch == "i686"
+          then "1k2zwh7jy8a65q3nxwx8pxja1ab1m3cy9vaf6k02q27h51w64a4z"
+          else "00m3fad068w93ycd36fgh79jqyhpb0fji1zw65lqifz29cl5876q";
+      };
+
+      phases = ["unpackPhase" "buildPhase"];
+
+      buildPhase = ''
+        _sln() { mkdir -p "$(dirname "$2")" && [ ! -e "$2" ] && ln -sf "$1" "$2"; }
+        _smv() { mkdir -p "$(dirname "$2")" && [ ! -e "$2" ] && mv "$1" "$2"; }
+        find . -type d \( \
+             -name 'audit' \
+          -o -name '.debug' \
+          -o -name 'locale' \
+          -o -name 'bin' \
+          -o -name 'sbin' \
+          -o -name 'var' \
+          -o -name 'etc' \
+        \) -exec rm -fr {} +
+
+        for dir in lib usr/lib; do
+          mv $dir{,.tmp}
+          _smv $dir{.tmp,/${arch}-linux-gnu}
+        done
+
+        _sln /etc usr/local/oe-sdk-hardcoded-buildpath/sysroots/${arch}-pokysdk-linux/etc
+        ${
+          if arch == "i686"
+          then ''
+            _sln /lib/i686-linux-gnu/ld-linux.so.2 lib/ld-linux.so.2
+            _sln /lib usr/local/oe-sdk-hardcoded-buildpath/sysroots/${arch}-pokysdk-linux/lib
+          ''
+          else ''
+            _sln /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 lib64/ld-linux-x86-64.so.2
+            _sln /lib64 usr/local/oe-sdk-hardcoded-buildpath/sysroots/${arch}-pokysdk-linux/lib
+          ''
+        }
+
+        ${lib.optionalString (!cc) ''
+          rm usr/lib/${arch}-linux-gnu/libstdc++*
+          rm lib/${arch}-linux-gnu/libgcc*
+        ''}
+
+        cp -a . $out/
+      '';
+    };
+  genMetadata = variant: let
+    inherit (variant) arch cc;
+    join = sep: parts: concatStringsSep sep (filter (s: s != "") parts);
+  in {
+    name = join "-" [
+      arch
+      (optionalString cc "cc")
+    ];
   };
 in
-  stdenv.mkDerivation {
-    inherit pname version src;
-    name = "${pname}-${version}-${uninative-arch}-sysroot";
-
-    phases = ["unpackPhase" "buildPhase"];
-
-    buildPhase = ''
-      _sln() { mkdir -p "$(dirname "$2")" && [ ! -e "$2" ] && ln -sf "$1" "$2"; }
-      _smv() { mkdir -p "$(dirname "$2")" && [ ! -e "$2" ] && mv "$1" "$2"; }
-
-      find . -type d -name 'audit' -o -name '.debug' -o -name 'locale' | xargs rm -rf
-      rm -rf usr/bin sbin var etc/ld.so.*
-
-      for dir in lib usr/lib; do
-        mv $dir{,.tmp}
-        _smv $dir{.tmp,/${uninative-arch}-linux-gnu}
-      done
-
-      _sln /etc usr/local/oe-sdk-hardcoded-buildpath/sysroots/${uninative-arch}-pokysdk-linux/etc
-      if [ "${uninative-arch}" = "i686" ]; then
-          _sln /lib/i686-linux-gnu/ld-linux.so.2 lib/ld-linux.so.2
-          _sln /lib usr/local/oe-sdk-hardcoded-buildpath/sysroots/${uninative-arch}-pokysdk-linux/lib
-      elif [ "${uninative-arch}" = "x86_64" ]; then
-          _sln /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 lib64/ld-linux-x86-64.so.2
-          _sln /lib64 usr/local/oe-sdk-hardcoded-buildpath/sysroots/${uninative-arch}-pokysdk-linux/lib
-      fi
-
-      cp -a . $out/
-    '';
-  }
+  listToAttrs (map (variant: let
+    inherit (genMetadata variant) name;
+  in
+    nameValuePair name (buildUninative {
+      inherit name;
+      inherit (variant) arch cc;
+    }))
+  variants)


### PR DESCRIPTION
This update introduces additional variants for the container images, allowing
builds with or without the libstdcxx library.

The new combinations available include:
- ash
- ash-i686
- ash-i686-cc-x86_64
- ash-i686-cc-x86_64-cc
- ash-x86_64
- ash-x86_64-cc
- i686
- i686-cc
- i686-cc-x86_64
- i686-cc-x86_64-cc
- i686-x86_64
- i686-x86_64-cc
- x86_64
- x86_64-cc

For test images, the new variants are:
- i686-cc
- x86_64-cc
- x86_64-cc-ubuntu