### PR TITLE
feat: adds user variants

### DIFF
--- a/nix/containers/images.nix
+++ b/nix/containers/images.nix
@@ -29,6 +29,7 @@
     title,
     description,
     includeShell,
+    rootUser,
   }: {
     Cmd = optional includeShell "/bin/sh";
     Env = optional includeShell "PATH=/bin";
@@ -39,19 +40,24 @@
       "org.opencontainers.image.description" = description;
     };
     Workdir = "/";
+    User =
+      if rootUser
+      then "root"
+      else "nonroot";
   };
 
   buildStarterKit = {
     name,
     includeShell,
     archs,
+    rootUser,
     description,
   }: rec {
     image = dockerTools.buildImage {
       inherit name;
       keepContentsDirlinks = true;
       config = imageConfig {
-        inherit description includeShell;
+        inherit description includeShell rootUser;
         title = "starterkit-${name}";
       };
       copyToRoot = optionals includeShell [busyboxStatic] ++ map (arch: uninative.${arch}) archs;
@@ -63,9 +69,38 @@
           '') (map (removeSuffix "-cc") archs)}
           exec ${glibc.bin}/bin/ldconfig -v -f etc/ld.so.conf -C etc/ld.so.cache -r $PWD
         '';
+        userSetup = let
+          inherit
+            (
+              (
+                if rootUser
+                then {
+                  user = "root";
+                  uid = "0";
+                }
+                else {
+                  user = "nonroot";
+                  uid = "65532";
+                }
+              )
+              // (
+                if includeShell
+                then {shell = "/bin/sh";}
+                else {shell = "/dev/null";}
+              )
+            )
+            user
+            uid
+            shell
+            ;
+        in ''
+          echo "${user}:x:${uid}:${user}" > etc/group
+          echo "${user}:x:${uid}:${uid}::/:${shell}" > etc/passwd
+        '';
       in ''
         chmod -R u+w .
         mkdir -p etc
+        ${userSetup}
         ${ldSetup}
         chmod -R u-w .
       '';
@@ -86,20 +121,23 @@
       ["i686" "x86_64-cc"]
       ["i686-cc" "x86_64-cc"]
     ];
+    rootUser = [false true];
   };
 
   genMetadata = variant: let
-    inherit (variant) includeShell archs;
+    inherit (variant) includeShell archs rootUser;
     join = sep: parts: concatStringsSep sep (filter (s: s != "") parts);
   in {
     name = join "-" [
       (optionalString includeShell "ash")
       (optionalString (archs != []) (concatStringsSep "-" archs))
+      (optionalString rootUser "root")
     ];
     description = join " " [
       "Barebone container image"
       (optionalString includeShell "with a minimal shell (busybox sh)")
       (optionalString (archs != []) "providing glibc support for ${concatStringsSep " " archs} architecture(s)")
+      (optionalString rootUser "as root" + optionalString (!rootUser) "as non-root")
     ];
   };
 in
@@ -108,6 +146,6 @@ in
   in
     nameValuePair name (buildStarterKit {
       inherit name description;
-      inherit (variant) includeShell archs;
+      inherit (variant) includeShell archs rootUser;
     }))
   variants)


### PR DESCRIPTION
This update introduces additional variants for the container images, allowing builds with or without root user.

The new combinations available include:
- ash
- ash-i686
- ash-i686-cc-x86_64
- ash-i686-cc-x86_64-cc
- ash-i686-cc-x86_64-cc-root
- ash-i686-cc-x86_64-root
- ash-i686-root
- ash-i686-x86_64-cc-root
- ash-i686-x86_64-root
- ash-root
- ash-x86_64
- ash-x86_64-cc
- i686
- i686-cc
- i686-cc-root
- i686-cc-x86_64
- i686-cc-x86_64-cc
- i686-cc-x86_64-cc-root
- i686-root
- i686-x86_64
- i686-x86_64-cc
- i686-x86_64-cc-root
- i686-x86_64-root
- root
- x86_64
- x86_64-cc
- x86_64-cc-root
- x86_64-root