### PR TITLE
refactor: package structure and use callPackage

### DIFF
--- a/nix/containers/default.nix
+++ b/nix/containers/default.nix
@@ -1,0 +1,14 @@
+{callPackage}: let
+  buildPushContainerScript = callPackage ./push.nix {};
+  containerImages = callPackage ./images.nix {
+    inherit buildPushContainerScript;
+  };
+  testContainerImages = callPackage ./tests.nix {
+    inherit buildPushContainerScript containerImages;
+  };
+  pushAllContainerImages = callPackage ./pushAll.nix {
+    inherit containerImages;
+  };
+in {
+  inherit containerImages testContainerImages pushAllContainerImages;
+}

--- a/nix/containers/images.nix
+++ b/nix/containers/images.nix
@@ -3,9 +3,8 @@
   dockerTools,
   glibc,
   lib,
-  skopeo,
   uninative,
-  writeShellScript,
+  buildPushContainerScript,
 }: let
   inherit
     (lib)
@@ -20,10 +19,6 @@
     optionalString
     removeSuffix
     ;
-
-  buildPushContainerScript = import ./push.nix {
-    inherit lib skopeo writeShellScript;
-  };
 
   imageConfig = {
     title,

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -1,0 +1,6 @@
+{callPackage}: {
+  busyboxStatic = callPackage ./busyboxStatic.nix {};
+  uninative = callPackage ./uninative.nix {};
+  helloWorldGlibc = callPackage ./helloWorldGlibc.nix {};
+  ubuntuDateutils = callPackage ./ubuntuDateutils.nix {};
+}


### PR DESCRIPTION
The main changes include:
- Introduce an overlayed callPackage mechanism in the top-level default.nix
- Move package, and image-level definitions to dedicated directories
- Update the helloWorldGlibc package to use a variant approach instead of relying on the is32Bit attribute
- Adjust the container image tests to work with the updated package structure and use the callPackage mechanism