### PR TITLE
fix: mechanism to push images

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,8 +20,5 @@ jobs:
 
       - name: "Build and publish the images"
         shell: bash
-        env:
-          harbor_user: ${{ secrets.harbor_user }}
-          harbor_token: ${{ secrets.harbor_token }}
         run: |2
-          $(nix-build --no-out-link default.nix -A pushAllContainerImages) harbor.apps.morrigna.rules-nix.build/explore-bzl "${HARBOR_USER}" "${HARBOR_TOKEN}"
+          $(nix-build --no-out-link default.nix -A pushAllContainerImages) harbor.apps.morrigna.rules-nix.build/explore-bzl '${{ secrets.harbor_user }}' '${{ secrets.harbor_token }}'

--- a/nix/containers/images.nix
+++ b/nix/containers/images.nix
@@ -71,7 +71,6 @@
   variants = cartesianProductOfSets {
     includeShell = [false true];
     archs = [
-      []
       ["i686"]
       ["i686-cc"]
       ["x86_64"]


### PR DESCRIPTION
Disallow the creation of completely empty image and attempt to fix the github action (by passing credentials as 'values').