### PR TITLE
fix: missing ash image variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The images are built using [nix](https://nixos.org/explore/) but they can be use
 <!-- BEGIN mdsh -->
 | Image | Pull |
 | ---   | ---  |
+| ash | `harbor.apps.morrigna.rules-nix.build/explore-bzl/ash:9m7shakbx4g5afqggrjml6d9ysw64kgl` |
 | ash-i686 | `harbor.apps.morrigna.rules-nix.build/explore-bzl/ash-i686:8yg4l9249799q4ydvni5rp9mqdxjkimq` |
 | ash-i686-cc | `harbor.apps.morrigna.rules-nix.build/explore-bzl/ash-i686-cc:13dhvdm6z1hm1s7mfydhijvf7h64rs52` |
 | ash-i686-cc-x86_64 | `harbor.apps.morrigna.rules-nix.build/explore-bzl/ash-i686-cc-x86_64:aryxnryzd2jvg6pah2r7vy0n08dbkdr4` |

--- a/nix/containers/images.nix
+++ b/nix/containers/images.nix
@@ -68,19 +68,22 @@
     push = buildPushContainerScript image;
   };
 
-  variants = cartesianProductOfSets {
-    includeShell = [false true];
-    archs = [
-      ["i686"]
-      ["i686-cc"]
-      ["x86_64"]
-      ["x86_64-cc"]
-      ["i686" "x86_64"]
-      ["i686-cc" "x86_64"]
-      ["i686" "x86_64-cc"]
-      ["i686-cc" "x86_64-cc"]
-    ];
-  };
+  variants =
+    filter (variant: variant.includeShell != false || variant.archs != [])
+    (cartesianProductOfSets {
+      includeShell = [false true];
+      archs = [
+        []
+        ["i686"]
+        ["i686-cc"]
+        ["x86_64"]
+        ["x86_64-cc"]
+        ["i686" "x86_64"]
+        ["i686-cc" "x86_64"]
+        ["i686" "x86_64-cc"]
+        ["i686-cc" "x86_64-cc"]
+      ];
+    });
 
   genMetadata = variant: let
     inherit (variant) includeShell archs;


### PR DESCRIPTION
This change restores `ash` image variant, and filters out `empty` variant.