### PR TITLE
feat: add bubblewrap outputs

### DIFF
--- a/nix/containers/bwrap.nix
+++ b/nix/containers/bwrap.nix
@@ -1,0 +1,31 @@
+{
+  stdenv,
+  skopeo,
+  bubblewrap,
+  umoci,
+  writeShellScript,
+  jq,
+}: containerImageDrv: let
+  rootfs = stdenv.mkDerivation {
+    name = "${containerImageDrv.imageName}.rootfs";
+    buildInputs = [skopeo umoci bubblewrap];
+
+    buildCommand = ''
+      skopeo copy --tmpdir=$TMPDIR --insecure-policy docker-archive:${containerImageDrv} oci:img:0
+
+      mkdir bundle
+      umoci raw unpack --rootless --image img:0 rootfs/
+
+      mkdir -p $out
+      cp -r rootfs $out/
+      skopeo inspect --config --tmpdir=$TMPDIR --insecure-policy docker-archive:${containerImageDrv} > $out/config.json
+    '';
+  };
+in
+  writeShellScript "${containerImageDrv.imageName}.bwrap" ''
+    ${bubblewrap}/bin/bwrap \
+      --ro-bind ${rootfs}/rootfs / \
+      --unshare-all \
+      --chdir / \
+      $(${jq}/bin/jq -r .config.Cmd[] ${rootfs}/config.json)
+  ''

--- a/nix/containers/default.nix
+++ b/nix/containers/default.nix
@@ -1,10 +1,11 @@
 {callPackage}: let
   buildPushContainerScript = callPackage ./push.nix {};
+  mkBwrapEnv = callPackage ./bwrap.nix {};
   containerImages = callPackage ./images.nix {
-    inherit buildPushContainerScript;
+    inherit buildPushContainerScript mkBwrapEnv;
   };
   testContainerImages = callPackage ./tests.nix {
-    inherit buildPushContainerScript containerImages;
+    inherit buildPushContainerScript mkBwrapEnv containerImages;
   };
   pushAllContainerImages = callPackage ./pushAll.nix {
     inherit containerImages;

--- a/nix/containers/images.nix
+++ b/nix/containers/images.nix
@@ -5,6 +5,7 @@
   lib,
   uninative,
   buildPushContainerScript,
+  mkBwrapEnv,
 }: let
   inherit
     (lib)
@@ -41,7 +42,7 @@
     includeShell,
     archs,
     description,
-  }: rec {
+  }: let
     image = dockerTools.buildImage {
       inherit name;
       keepContentsDirlinks = true;
@@ -65,8 +66,16 @@
         chmod -R u-w .
       '';
     };
-    push = buildPushContainerScript image;
-  };
+  in
+    {
+      inherit image;
+      push = buildPushContainerScript image;
+    }
+    // (
+      if includeShell
+      then {bwrap = mkBwrapEnv image;}
+      else {}
+    );
 
   variants = cartesianProductOfSets {
     includeShell = [false true];

--- a/nix/containers/tests.nix
+++ b/nix/containers/tests.nix
@@ -4,6 +4,7 @@
   lib,
   helloWorldGlibc,
   buildPushContainerScript,
+  mkBwrapEnv,
   ubuntuDateutils,
 }: let
   buildStarterKitTest = {
@@ -19,6 +20,7 @@
       config = {Cmd = cmd;};
     };
     push = buildPushContainerScript image;
+    bwrap = mkBwrapEnv image;
   };
 in
   lib.genAttrs ["i686-cc" "x86_64-cc"] (arch:


### PR DESCRIPTION
This update introduces `bwrap` outputs for all images that define the `Cmd` attribute. The `bwrap` outputs enable direct access to the image's root filesystem without requiring a container runtime on the host machine.

For instance, to run the dateutils test image, execute: `$(nix-build -A testContainerImages.x86_64-cc-ubuntu.bwrap)`