### PR TITLE
feat: introduce simple script for running the test images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: "ci"
+run-name: "Run test container images for commit ${{ github.sha }}"
+
+on:
+  pull_request:
+    branches: ["canon"]
+  push:
+    branches: ["canon"]
+
+jobs:
+  build-and-run-test-images:
+    name: "build-and-run-test-images"
+    runs-on: ["ubuntu-latest"]
+    steps:
+      - name: "Install nix"
+        uses: cachix/install-nix-action@v26
+
+      - name: "Checkout 'canon' branch of the repo"
+        uses: actions/checkout@v4
+        with:
+          clean: true
+
+      - name: "Build and run test images"
+        shell: bash
+        run: |2
+          $(nix-build --no-out-link default.nix -A runAllTestContainerImages)

--- a/nix/containers/default.nix
+++ b/nix/containers/default.nix
@@ -10,6 +10,9 @@
   pushAllContainerImages = callPackage ./pushAll.nix {
     inherit containerImages;
   };
+  runAllTestContainerImages = callPackage ./runTests.nix {
+    inherit testContainerImages;
+  };
 in {
-  inherit containerImages testContainerImages pushAllContainerImages;
+  inherit containerImages testContainerImages pushAllContainerImages runAllTestContainerImages;
 }

--- a/nix/containers/runTests.nix
+++ b/nix/containers/runTests.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  writeShellScript,
+  testContainerImages,
+}: let
+  buildTestsScript = testContainerImages:
+    writeShellScript "tests.sh" ''
+      set -euo pipefail
+
+      echo "[starterkit] execution of test images started.."
+      ${
+        (
+          builtins.foldl'
+          (acc: current: acc + "${current}\n")
+          ""
+          (lib.mapAttrsToList (_: v: builtins.getAttr "bwrap" v) (lib.filterAttrs (_: val: builtins.isAttrs val && (builtins.hasAttr "image" val)) testContainerImages))
+        )
+      }
+      echo "[starterkit] execution of test images finished successfully!"
+    '';
+in
+  buildTestsScript testContainerImages

--- a/nix/containers/tests.nix
+++ b/nix/containers/tests.nix
@@ -34,7 +34,7 @@ in
       cmd = ["/bin/hello_cpp"];
     })
   // {
-    "x86_64-cc-ubuntu" = buildStarterKitTest {
+    "ash-x86_64-cc-ubuntu" = buildStarterKitTest {
       name = "starterkit-x86_64-cc-testUbuntuDateutils";
       testImage = containerImages."ash-x86_64-cc".image;
       testBinary = ubuntuDateutils;


### PR DESCRIPTION
This change introduces a simply script that attemtps to run
all of the test images via bubblewrap. It's goal is to rudimentary
check the correctnes of produced images.

Additonally a github action has been introduced to run the check
per each commit to cannon and on each PR.