### PR TITLE
refactor: compile test binaries using gccMultiStdenv

### DIFF
--- a/nix/pkgs/helloWorldGlibc.nix
+++ b/nix/pkgs/helloWorldGlibc.nix
@@ -1,40 +1,15 @@
 {
-  stdenv,
   patchelf,
   removeReferencesTo,
   writeTextDir,
-  system,
-  wrapCCWith,
-  wrapBintoolsWith,
-  binutils-unwrapped,
-  overrideCC,
-  pkgsi686Linux,
-  path,
   lib,
+  gccMultiStdenv,
 }: let
-  inherit (lib) cartesianProductOfSets nameValuePair listToAttrs;
+  inherit (lib) cartesianProductOfSets nameValuePair listToAttrs optionalString;
 
   variants = cartesianProductOfSets {
     arch = ["x86_64" "i686"];
   };
-
-  createOverriddenStdenv = {
-    path,
-    binutils-unwrapped,
-    crossSystem ? null,
-  }: let
-    nixpkgs = import path {
-      inherit crossSystem system;
-    };
-    wrappedGcc = wrapCCWith {
-      cc = nixpkgs.gcc-unwrapped;
-      bintools = wrapBintoolsWith {
-        bintools = binutils-unwrapped;
-        libc = nixpkgs.glibc;
-      };
-    };
-  in
-    overrideCC stdenv wrappedGcc;
 
   createSource = name: code: writeTextDir name code;
 
@@ -58,35 +33,24 @@
     name,
     arch,
   }: let
-    overriddenStdenv = createOverriddenStdenv {
-      inherit path;
-      crossSystem =
-        if arch == "i686"
-        then {config = "i686-linux";}
-        else null;
-      binutils-unwrapped =
-        if arch == "i686"
-        then pkgsi686Linux.binutils-unwrapped
-        else binutils-unwrapped;
-    };
     interpreter =
       if arch == "i686"
       then "/lib/ld-linux.so.2"
       else "/lib64/ld-linux-x86-64.so.2";
   in
-    overriddenStdenv.mkDerivation {
+    gccMultiStdenv.mkDerivation {
       name = "hello-world-dynamic-nostore-${name}";
       nativeBuildInputs = [patchelf removeReferencesTo];
       phases = ["buildPhase" "installPhase"];
       buildPhase = ''
-        gcc ${src}/hello.c -o hello_c
-        g++ ${srcCpp}/hello.cpp -o hello_cpp
+        gcc ${src}/hello.c ${optionalString (arch == "i686") "-m32"} -o hello_c
+        g++ ${srcCpp}/hello.cpp ${optionalString (arch == "i686") "-m32"} -o hello_cpp
       '';
       installPhase = ''
         mkdir -p $out/bin
         cp hello* $out/bin/
         find "$out" -type f -exec patchelf --set-interpreter ${interpreter} --remove-rpath '{}' +
-        find "$out" -type f -exec remove-references-to -t ${overriddenStdenv.cc.libc} -t ${overriddenStdenv.cc.cc.lib} -t $out '{}' +
+        find "$out" -type f -exec remove-references-to -t ${gccMultiStdenv.cc.libc} -t ${gccMultiStdenv.cc.cc.lib} -t $out '{}' +
       '';
     };
 


### PR DESCRIPTION
This update removes custom stdenv used for building i686 variant of helloWorldGlibc with upstream gccMultiStdenv.