### PR TITLE
refactor: extract common functions to nix/lib

### DIFF
--- a/nix/containers/push.nix
+++ b/nix/containers/push.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   skopeo,
   writeShellScript,
 }: let

--- a/nix/containers/tests.nix
+++ b/nix/containers/tests.nix
@@ -1,17 +1,19 @@
 {
   containerImages,
   dockerTools,
-  lib,
   helloWorldGlibc,
   buildPushContainerScript,
   mkBwrapEnv,
   ubuntuDateutils,
+  genVariants,
+  buildPackages,
 }: let
   buildStarterKitTest = {
     name,
     testImage,
     testBinary,
     cmd,
+    ...
   }: rec {
     image = dockerTools.buildImage {
       inherit name;
@@ -22,22 +24,32 @@
     push = buildPushContainerScript image;
     bwrap = mkBwrapEnv image;
   };
-in
-  lib.genAttrs ["i686-cc" "x86_64-cc"] (arch:
-    buildStarterKitTest {
-      name = "starterkit-${arch}-helloWorldGlibc";
-      testImage = containerImages."ash-${arch}".image;
-      testBinary = let
-        cleanArch = builtins.replaceStrings ["-cc"] [""] arch;
-      in
-        helloWorldGlibc.${cleanArch};
-      cmd = ["/bin/hello_cpp"];
-    })
-  // {
+
+  genMetadata = variant: {
+    name = "ash-${variant.arch}";
+    testImage = containerImages."ash-${variant.arch}".image;
+    testBinary = helloWorldGlibc."${(builtins.replaceStrings ["-cc"] [""] variant.arch)}";
+    cmd = ["/bin/hello_cpp"];
+  };
+
+  variants = genVariants {
+    attrs = {
+      arch = ["i686-cc" "x86_64-cc"];
+    };
+  };
+
+  ubuntuVariant = {
     "ash-x86_64-cc-ubuntu" = buildStarterKitTest {
       name = "starterkit-x86_64-cc-testUbuntuDateutils";
       testImage = containerImages."ash-x86_64-cc".image;
       testBinary = ubuntuDateutils;
       cmd = ["/bin/dateutils.dseq" "2024-04-01" "2024-04-25" "--skip" "sat,sun"];
     };
+  };
+in
+  buildPackages {
+    metaFun = genMetadata;
+    buildFun = buildStarterKitTest;
+    variants = variants;
   }
+  // ubuntuVariant

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -9,7 +9,6 @@
   niv,
   statix,
   deadnix,
-  mdsh,
 } @ args: let
   packages = lib.attrsets.attrValues (
     builtins.removeAttrs args ["mkShell" "lib"]

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -1,0 +1,31 @@
+{lib}: let
+  inherit
+    (lib)
+    cartesianProductOfSets
+    concatStringsSep
+    filter
+    nameValuePair
+    listToAttrs
+    ;
+in {
+  join = sep: parts: concatStringsSep sep (filter (s: s != "") parts);
+
+  genVariants = {
+    filter ? null,
+    attrs,
+  }:
+    if builtins.isNull filter
+    then (cartesianProductOfSets attrs)
+    else filter (cartesianProductOfSets attrs);
+
+  buildPackages = {
+    metaFun,
+    buildFun,
+    variants,
+  }:
+    listToAttrs (map (variant: let
+      meta = metaFun variant;
+    in
+      nameValuePair meta.name (buildFun (meta // variant)))
+    variants);
+}

--- a/nix/pkgs/uninative.nix
+++ b/nix/pkgs/uninative.nix
@@ -1,26 +1,22 @@
 {
   stdenv,
   fetchurl,
+  genVariants,
+  join,
+  buildPackages,
   lib,
 }: let
-  inherit
-    (lib)
-    cartesianProductOfSets
-    concatStringsSep
-    filter
-    nameValuePair
-    listToAttrs
-    optionalString
-    ;
-
-  name = "yocto-uninative";
   version = "4.4";
   baseURL = "http://downloads.yoctoproject.org/releases/uninative";
 
-  variants = cartesianProductOfSets {
-    arch = ["x86_64" "i686"];
-    cc = [true false];
-  };
+  fetchSource = arch:
+    fetchurl {
+      url = "${baseURL}/${version}/${arch}-nativesdk-libc.tar.xz";
+      sha256 =
+        if arch == "i686"
+        then "1k2zwh7jy8a65q3nxwx8pxja1ab1m3cy9vaf6k02q27h51w64a4z"
+        else "00m3fad068w93ycd36fgh79jqyhpb0fji1zw65lqifz29cl5876q";
+    };
 
   buildUninative = {
     name,
@@ -28,15 +24,8 @@
     cc,
   }:
     stdenv.mkDerivation {
-      inherit name;
-
-      src = fetchurl {
-        url = "${baseURL}/${version}/${arch}-nativesdk-libc.tar.xz";
-        sha256 =
-          if arch == "i686"
-          then "1k2zwh7jy8a65q3nxwx8pxja1ab1m3cy9vaf6k02q27h51w64a4z"
-          else "00m3fad068w93ycd36fgh79jqyhpb0fji1zw65lqifz29cl5876q";
-      };
+      name = "yocto-uninative-${name}";
+      src = fetchSource arch;
 
       phases = ["unpackPhase" "buildPhase"];
 
@@ -79,21 +68,21 @@
         cp -a . $out/
       '';
     };
-  genMetadata = variant: let
+
+  genMetadata = variant: rec {
     inherit (variant) arch cc;
-    join = sep: parts: concatStringsSep sep (filter (s: s != "") parts);
-  in {
-    name = join "-" [
-      arch
-      (optionalString cc "cc")
-    ];
+    name = join "-" [arch (lib.optionalString cc "cc")];
+  };
+
+  variants = genVariants {
+    attrs = {
+      arch = ["x86_64" "i686"];
+      cc = [true false];
+    };
   };
 in
-  listToAttrs (map (variant: let
-    inherit (genMetadata variant) name;
-  in
-    nameValuePair name (buildUninative {
-      inherit name;
-      inherit (variant) arch cc;
-    }))
-  variants)
+  buildPackages {
+    metaFun = genMetadata;
+    buildFun = buildUninative;
+    variants = variants;
+  }


### PR DESCRIPTION
This update codifies commonly used patterns into library expression in `nix/lib` and reorganizes code for readability.