### PR TITLE
feat(cicd): introduce automated releasing process

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
           # it can be ignored. 
           nix_path: nixpkgs=channel:nixos-unstable
 
-      - name: "Checkout 'canon' branch of the repo"
+      - name: "Checkout target branch of the repo"
         uses: actions/checkout@v4
         with:
           clean: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,17 +1,21 @@
-name: "publish"
-run-name: "Publish changes for commit ${{ github.sha }}"
+name: "release"
+run-name: "Release from commit ${{ github.sha }}"
 
 on:
   push:
     branches: ["canon"]
-    tags:
-      # Run only for releases
+    tags-ignore:
+      # Never run for releases
       - 'v*'
 
 jobs:
-  publish:
-    name: "publish"
+  release:
+    name: "release"
     runs-on: ["ubuntu-latest"]
+    defaults:
+      run:
+        shell: nix-shell --run "set -eo pipefail; source {0}"
+ 
     steps:
       - name: "Install nix"
         uses: cachix/install-nix-action@v26
@@ -35,22 +39,22 @@ jobs:
           # This is important, we do not do merges
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: "Publish the images to harbor"
-        shell: bash
+      - name: "Set git users for release commit"
         run: |2
-          $(nix-build --no-out-link default.nix -A images.all.push) harbor.apps.morrigna.rules-nix.build/explore-bzl '${{ secrets.harbor_user }}' '${{ secrets.harbor_token }}'
+          git config user.name "Github Actions"
+          git config user.email "actions@github.com"
 
-      - name: "Get project meta"
-        id: get_project_meta
-        shell: bash
+      - name: "Auto-release"
         run: |2
-          export version="v$(nix-shell --run 'cog get-version 2>/dev/null')"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          nix-shell --run "cog changelog --at ${version}" >./release-notes.md 2>/dev/null
+          cog bump --auto --annotated 'automated release'
 
-      - name: "Create GitHub release"
-        uses: ncipollo/release-action@v1
-        with:
-          bodyFile: ./release-notes.md
-          makeLatest: "legacy"
-          tag: ${{ steps.get_project_meta.outputs.version }}
+      - name: "Push changes"
+        run: |2
+          if [ $(git rev-list HEAD...origin/canon --ignore-submodules --count) -eq 0 ]; then
+            echo "No commits to be pushed."
+            exit 0
+          fi
+
+          # We are pushing the changes only if there are commits to be pushed
+          git push
+          git push --tags


### PR DESCRIPTION
This change ensures that any commit made to the 'canon' branch, will trigger relesing process and thus ensure always-up-to-date release of the project.