### PR TITLE
feat(test): adds justbuild test images

### DIFF
--- a/nix/images/tests/default.nix
+++ b/nix/images/tests/default.nix
@@ -5,6 +5,7 @@
   buildPushContainerScript,
   mkBwrapEnv,
   ubuntuDateutils,
+  justbuild,
   buildPackages,
 }: let
   buildStarterKitTest = {
@@ -24,13 +25,6 @@
     bwrap = mkBwrapEnv image;
   };
 
-  genMetadata = variant: {
-    name = "ash-${variant.arch}";
-    testImage = containerImages."ash-${variant.arch}".image;
-    testBinary = helloWorldGlibc."${(builtins.replaceStrings ["-cc"] [""] variant.arch)}";
-    cmd = ["/bin/hello_cpp"];
-  };
-
   ubuntuVariant = {
     "ash-x86_64-cc-ubuntu" = buildStarterKitTest {
       name = "starterkit-x86_64-cc-testUbuntuDateutils";
@@ -41,7 +35,26 @@
   };
 in
   buildPackages {
-    metaFun = genMetadata;
+    metaFun = variant: {
+      name = "ash-${variant.arch}-hello";
+      testImage = containerImages."ash-${variant.arch}".image;
+      testBinary = helloWorldGlibc."${(builtins.replaceStrings ["-cc"] [""] variant.arch)}";
+      cmd = ["/bin/hello_cpp"];
+    };
+    buildFun = buildStarterKitTest;
+    variants = {
+      attrs = {
+        arch = ["i686-cc" "x86_64-cc"];
+      };
+    };
+  }
+  // buildPackages {
+    metaFun = variant: {
+      name = "ash-${variant.arch}-just";
+      testImage = containerImages."ash-${variant.arch}".image;
+      testBinary = justbuild;
+      cmd = ["/bin/just" "--help"];
+    };
     buildFun = buildStarterKitTest;
     variants = {
       attrs = {

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -3,4 +3,5 @@
   uninative = callPackage ./uninative {};
   helloWorldGlibc = callPackage ./hello {};
   ubuntuDateutils = callPackage ./dateutils {};
+  justbuild = callPackage ./justbuild {};
 }

--- a/nix/pkgs/justbuild/default.nix
+++ b/nix/pkgs/justbuild/default.nix
@@ -1,0 +1,13 @@
+{stdenv}:
+stdenv.mkDerivation {
+  name = "justbuild";
+  version = "1.3.0";
+
+  src = builtins.fetchTarball {
+    url = "https://github.com/oreiche/justbuild/releases/download/v1.3.0/justbuild-1.3.0-x86_64-linux.tar.gz";
+    sha256 = "1s8r5s8yy936zn81lp6mpbx8xmw288pkqfc9i7h4r91dfg9qlaga";
+  };
+
+  phases = ["unpackPhase" "installPhase"];
+  installPhase = "mkdir $out && mv * $out";
+}


### PR DESCRIPTION
This update adds test images with statically linked `just` binary.

New images can be used as starterkit-based, remote build runners:
```
nix-build -A images.test.ash-x86_64-cc-just.bwrap
./result /bin/just execute --compatible -p 7777 -i 0.0.0.0
```