### PR TITLE
feat: new image variant containing strace

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "57d6973abba7ea108bac64ae7629e7431e0199b6",
-        "sha256": "1sx6ijjj0cic06khxb13iaihqadwm8drixy9rw32xapdvj6x92pm",
+        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
+        "sha256": "0zrl64ndfkkc4zhykrnc03b9ymp793zzmjqy3jfi9ckkni5vviqb",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/57d6973abba7ea108bac64ae7629e7431e0199b6.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/b2852eb9365c6de48ffb0dc2c9562591f652242a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This change introduces a new image variant, that contains statically built
strace to the image. The goal is to allow easier debugging of hermeticy
leaks via Bazel '--run_under' [1] flag.

[1] https://bazel.build/reference/command-line-reference#flag--run_under