### PR TITLE
fix: strace images contain /nix/store

### DIFF
--- a/nix/images/images.nix
+++ b/nix/images/images.nix
@@ -1,6 +1,6 @@
 {
   busyboxStatic,
-  pkgsStatic,
+  straceStatic,
   dockerTools,
   glibc,
   lib,
@@ -46,7 +46,7 @@
     description,
   }: let
     config = genImageConfig {inherit name includeShell description;};
-    copyToRoot = optionals includeShell [busyboxStatic] ++ optionals includeStrace [pkgsStatic.strace] ++ map (arch: uninative.${arch}) archs;
+    copyToRoot = optionals includeShell [busyboxStatic] ++ optionals includeStrace [straceStatic] ++ map (arch: uninative.${arch}) archs;
     ldSetupCommands = concatMapStringsSep "\n" (arch: ''
       echo /lib/${arch}-linux-gnu >> etc/ld.so.conf
       echo /usr/lib/${arch}-linux-gnu >> etc/ld.so.conf

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -1,5 +1,6 @@
 {callPackage}: {
   busyboxStatic = callPackage ./busybox {};
+  straceStatic = callPackage ./strace {};
   uninative = callPackage ./uninative {};
   helloWorldGlibc = callPackage ./hello {};
   ubuntuDateutils = callPackage ./dateutils {};

--- a/nix/pkgs/strace/default.nix
+++ b/nix/pkgs/strace/default.nix
@@ -1,0 +1,14 @@
+{
+  stdenv,
+  pkgsStatic,
+}:
+stdenv.mkDerivation {
+  name = "strace-static-hardcopy";
+
+  phases = ["buildPhase"];
+
+  buildPhase = ''
+    mkdir -p $out/bin
+    cp ${pkgsStatic.strace}/bin/strace $out/bin/strace
+  '';
+}


### PR DESCRIPTION
This commit ensures that the images produced with strace binary, will not contain any refernces (or files) from /nix/store.

![image](https://github.com/user-attachments/assets/800a4560-ce9d-4622-9c07-cd4a0729eeda)
