### PR TITLE
feat: update to uninative 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ None.
 
 Starterkit is not based upon any Linux distribution, and it obtains its `glibc` from the fantastic [Yocto Uninative project](https://docs.yoctoproject.org/gatesgarth/ref-manual/ref-classes.html#uninative-bbclass) which creates easily relocatable versions of the library.
 
-Currently used version of uninative: **4.4 (glibc 2.38)**.
+Currently used version of uninative: **4.6 (glibc 2.40)**.
 
 ## How to...
 

--- a/nix/docs/README.template.md
+++ b/nix/docs/README.template.md
@@ -18,7 +18,7 @@ None.
 
 Starterkit is not based upon any Linux distribution, and it obtains its `glibc` from the fantastic [Yocto Uninative project](https://docs.yoctoproject.org/gatesgarth/ref-manual/ref-classes.html#uninative-bbclass) which creates easily relocatable versions of the library.
 
-Currently used version of uninative: **4.4 (glibc 2.38)**.
+Currently used version of uninative: **4.6 (glibc 2.40)**.
 
 ## How to...
 

--- a/nix/pkgs/uninative/default.nix
+++ b/nix/pkgs/uninative/default.nix
@@ -5,7 +5,7 @@
   buildPackages,
   lib,
 }: let
-  version = "4.4";
+  version = "4.6";
   baseURL = "http://downloads.yoctoproject.org/releases/uninative";
 
   fetchSource = arch:
@@ -13,8 +13,8 @@
       url = "${baseURL}/${version}/${arch}-nativesdk-libc.tar.xz";
       sha256 =
         if arch == "i686"
-        then "1k2zwh7jy8a65q3nxwx8pxja1ab1m3cy9vaf6k02q27h51w64a4z"
-        else "00m3fad068w93ycd36fgh79jqyhpb0fji1zw65lqifz29cl5876q";
+        then "0041584678109c18deca48fb59eaf14cf725cf024a170ab537b354b63240c504"
+        else "6bf00154c5a7bc48adbf63fd17684bb87eb07f4814fbb482a3fbd817c1ccf4c5";
     };
 
   buildUninative = {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
-        "sha256": "0zrl64ndfkkc4zhykrnc03b9ymp793zzmjqy3jfi9ckkni5vviqb",
+        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
+        "sha256": "0gnmmn1wc09z1q4bb8jkqi2f8vxl26kaa3xrs664q9i651am2mkl",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b2852eb9365c6de48ffb0dc2c9562591f652242a.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a58bc8ad779655e790115244571758e8de055e3d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This change updates the version of uninative to 4.6 (glibc 2.40).

See the following link for more information: https://downloads.yoctoproject.org/releases/uninative/4.6/x86_64-nativesdk-libc.testdata.json