### PR TITLE
fix: images config entry cmd

### DIFF
--- a/nix/images/images.nix
+++ b/nix/images/images.nix
@@ -31,10 +31,10 @@
   }: {
     Cmd =
       if includeAsh
-      then "/bin/sh"
+      then ["/bin/sh"]
       else if includeBash
-      then "/bin/bash"
-      else "";
+      then ["/bin/bash"]
+      else [""];
     Env = optional (includeAsh || includeBash) "PATH=/bin";
     Labels = {
       "org.opencontainers.image.authors" = "r2r-dev,AleksanderGondek";


### PR DESCRIPTION
This changeset fixes the container images configuration 'Cmd' entry, which was wrongly set to be of type string, while it needs to be an array of strings.

Plese see the opencontainer initiative omage spec for details: [1]

[1] https://github.com/opencontainers/image-spec/blob/da92727e9c8761ec087890466b8756b755aefd37/specs-go/v1/config.go#L38