### PR TITLE
fix(ci): issues with using bubblewrap in github runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   validate-images:
     name: "validate-images"
-    runs-on: ["ubuntu-latest"]
+    runs-on: ["ubuntu-22.04"]
     defaults:
       run:
         shell: nix-shell --run "set -eo pipefail; source {0}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   publish:
     name: "publish"
-    runs-on: ["ubuntu-latest"]
+    runs-on: ["ubuntu-22.04"]
     steps:
       - name: "Install nix"
         uses: cachix/install-nix-action@v26

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ on:
 jobs:
   release:
     name: "release"
-    runs-on: ["ubuntu-latest"]
+    runs-on: ["ubuntu-22.04"]
     defaults:
       run:
         shell: nix-shell --run "set -eo pipefail; source {0}"


### PR DESCRIPTION
When using Bubblewrap (the bwrap command) to create a i container in Ubuntu 24.04 you can expect to get one of the following error messages:

bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted
bwrap: setting up uid map: Permission denied

This changeset pins down the version of Ubuntu
used by the gh-action runners to 22.04, so that
the CI may proceed.

See also: https://etbe.coker.com.au/2024/04/24/ubuntu-24-04-bubblewrap/