### PR TITLE
chore(images): adds writable tmp dir

### DIFF
--- a/nix/images/images.nix
+++ b/nix/images/images.nix
@@ -71,6 +71,8 @@
       ${optionalString (archs != []) ldSetupCommands}
       exec ${glibc.bin}/bin/ldconfig -v -f etc/ld.so.conf -C etc/ld.so.cache -r $PWD
       chmod -R u-w .
+      mkdir -p tmp
+      chmod 777 tmp
     '';
     image = dockerTools.buildImage {
       inherit name config copyToRoot extraCommands;


### PR DESCRIPTION
This change adds tmp directory that is wrtiable by everyone to all starterkit images.